### PR TITLE
Move the project to `CogitatorTech`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add logs to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/CogitatorTech/chilli/discussions
+    about: Please ask and answer general questions here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,17 @@ Contributions are always welcome and appreciated.
 
 ### How to Contribute
 
-Please check the [issue tracker](https://github.com/habedi/chilli/issues) to see if there is an issue you
+Please check the [issue tracker](https://github.com/CogitatorTech/chilli/issues) to see if there is an issue you
 would like to work on or if it has already been resolved.
 
 #### Reporting Bugs
 
-1. Open an issue on the [issue tracker](https://github.com/habedi/chilli/issues).
+1. Open an issue on the [issue tracker](https://github.com/CogitatorTech/chilli/issues).
 2. Include information such as steps to reproduce the observed behavior and relevant logs or screenshots.
 
 #### Suggesting Features
 
-1. Open an issue on the [issue tracker](https://github.com/habedi/chilli/issues).
+1. Open an issue on the [issue tracker](https://github.com/CogitatorTech/chilli/issues).
 2. Provide details about the feature, its purpose, and potential implementation ideas.
 
 ### Submitting Pull Requests

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 <h2>Chilli</h2>
 
-[![Tests](https://img.shields.io/github/actions/workflow/status/habedi/chilli/tests.yml?label=tests&style=flat&labelColor=282c34&logo=github)](https://github.com/habedi/chilli/actions/workflows/tests.yml)
-[![CodeFactor](https://img.shields.io/codefactor/grade/github/habedi/chilli?label=code%20quality&style=flat&labelColor=282c34&logo=codefactor)](https://www.codefactor.io/repository/github/habedi/chilli)
+[![Tests](https://img.shields.io/github/actions/workflow/status/CogitatorTech/chilli/tests.yml?label=tests&style=flat&labelColor=282c34&logo=github)](https://github.com/CogitatorTech/chilli/actions/workflows/tests.yml)
+[![CodeFactor](https://img.shields.io/codefactor/grade/github/CogitatorTech/chilli?label=code%20quality&style=flat&labelColor=282c34&logo=codefactor)](https://www.codefactor.io/repository/github/CogitatorTech/chilli)
 [![Zig Version](https://img.shields.io/badge/Zig-0.15.1-orange?logo=zig&labelColor=282c34)](https://ziglang.org/download/)
-[![Docs](https://img.shields.io/badge/docs-view-blue?style=flat&labelColor=282c34&logo=read-the-docs)](https://habedi.github.io/chilli/)
-[![Examples](https://img.shields.io/badge/examples-view-green?style=flat&labelColor=282c34&logo=zig)](https://github.com/habedi/chilli/tree/main/examples)
-[![Release](https://img.shields.io/github/release/habedi/chilli.svg?label=release&style=flat&labelColor=282c34&logo=github)](https://github.com/habedi/chilli/releases/latest)
-[![License](https://img.shields.io/badge/license-MIT-007ec6?label=license&style=flat&labelColor=282c34&logo=open-source-initiative)](https://github.com/habedi/chilli/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-read-blue?style=flat&labelColor=282c34&logo=read-the-docs)](https://CogitatorTech.github.io/chilli/)
+[![Examples](https://img.shields.io/badge/examples-view-green?style=flat&labelColor=282c34&logo=zig)](https://github.com/CogitatorTech/chilli/tree/main/examples)
+[![Release](https://img.shields.io/github/release/CogitatorTech/chilli.svg?label=release&style=flat&labelColor=282c34&logo=github)](https://github.com/CogitatorTech/chilli/releases/latest)
+[![License](https://img.shields.io/badge/license-MIT-007ec6?label=license&style=flat&labelColor=282c34&logo=open-source-initiative)](https://github.com/CogitatorTech/chilli/blob/main/LICENSE)
 
 A microframework for creating command-line applications in Zig
 
@@ -44,7 +44,7 @@ You can add Chilli to your project and start using it by following the steps bel
 Run the following command in the root directory of your project to download Chilli:
 
 ```sh
-zig fetch --save=chilli "https://github.com/habedi/chilli/archive/<branch_or_tag>.tar.gz"
+zig fetch --save=chilli "https://github.com/CogitatorTech/chilli/archive/<branch_or_tag>.tar.gz"
 ```
 
 Replace `<branch_or_tag>` with the desired branch or tag, like `main` (for the development version) or `v0.2.0`
@@ -162,7 +162,7 @@ FLAGS:
 
 ### Documentation
 
-You can find the full API documentation for the latest release of Chilli [here](https://habedi.github.io/chilli/).
+You can find the full API documentation for the latest release of Chilli [here](https://CogitatorTech.github.io/chilli/).
 
 Alternatively, you can use the `make docs` command to generate the API documentation for the current version of Chilli
 from the source code.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/CogitatorTech/chilli/tests.yml?label=tests&style=flat&labelColor=282c34&logo=github)](https://github.com/CogitatorTech/chilli/actions/workflows/tests.yml)
 [![CodeFactor](https://img.shields.io/codefactor/grade/github/CogitatorTech/chilli?label=code%20quality&style=flat&labelColor=282c34&logo=codefactor)](https://www.codefactor.io/repository/github/CogitatorTech/chilli)
-[![Zig Version](https://img.shields.io/badge/Zig-0.15.1-orange?logo=zig&labelColor=282c34)](https://ziglang.org/download/)
-[![Docs](https://img.shields.io/badge/docs-read-blue?style=flat&labelColor=282c34&logo=read-the-docs)](https://CogitatorTech.github.io/chilli/)
+[![Zig Version](https://img.shields.io/badge/Zig-0.15.1-orange?logo=zig&labelColor=282c34)](https://ziglang.org/download)
+[![Docs](https://img.shields.io/badge/docs-read-blue?style=flat&labelColor=282c34&logo=read-the-docs)](https://CogitatorTech.github.io/chilli)
 [![Examples](https://img.shields.io/badge/examples-view-green?style=flat&labelColor=282c34&logo=zig)](https://github.com/CogitatorTech/chilli/tree/main/examples)
 [![Release](https://img.shields.io/github/release/CogitatorTech/chilli.svg?label=release&style=flat&labelColor=282c34&logo=github)](https://github.com/CogitatorTech/chilli/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT-007ec6?label=license&style=flat&labelColor=282c34&logo=open-source-initiative)](https://github.com/CogitatorTech/chilli/blob/main/LICENSE)
@@ -32,6 +32,12 @@ while being small and fast, and not getting in the way of your application logic
 - Supports generating automatic `--help` and `--version` output with custom sections
 - Uses a shared context to pass application state
 - Written in pure Zig with no external dependencies
+
+See the [ROADMAP.md](ROADMAP.md) for the list of implemented and planned features.
+
+> [!IMPORTANT]
+> Chilli is in early development, so bugs and breaking changes are expected.
+> Please use the [issues page](https://github.com/CogitatorTech/chilli/issues) to report bugs or request features.
 
 ---
 
@@ -162,7 +168,7 @@ FLAGS:
 
 ### Documentation
 
-You can find the full API documentation for the latest release of Chilli [here](https://CogitatorTech.github.io/chilli/).
+You can find the full API documentation for the latest release of Chilli [here](https://CogitatorTech.github.io/chilli).
 
 Alternatively, you can use the `make docs` command to generate the API documentation for the current version of Chilli
 from the source code.
@@ -171,35 +177,8 @@ and view in your web browser at [http://localhost:8000](http://localhost:8000).
 
 ### Examples
 
-Check out the [examples](examples/) directory for examples of how Chilli can be used to build a variety of CLI
+Check out the [examples](examples) directory for examples of how Chilli can be used to build a variety of CLI
 applications.
-
-### Feature Roadmap
-
--   [x] **Command Structure**
-    -   [x] Nested commands and subcommands
-    -   [x] Command aliases and single-character shortcuts
-    -   [x] Persistent flags (flags on parent commands are available to children)
-
--   [x] **Argument & Flag Parsing**
-    -   [x] Long flags (`--verbose`), short flags (`-v`), and grouped boolean flags (`-vf`)
-    -   [x] Positional Arguments (supports required, optional, and variadic)
-    -   [x] Type-safe access for flags and arguments (e.g., `ctx.getFlag("count", i64)`)
-    -   [x] Reading flag values from environment variables
-
--   [x] **Help & Usage Output**
-    -   [x] Automatic and context-aware `--help` flag
-    -   [x] Automatic `--version` flag
-    -   [x] Clean, aligned help output for commands, flags, and arguments
-    -   [x] Grouping subcommands into custom sections
-
--   [x] **Developer Experience**
-    -   [x] Simple, declarative API for building commands
-    -   [x] Named access for all flags and arguments
-    -   [x] Shared context data for passing application state
-    -   [ ] Deprecation notices for commands or flags
-    -   [ ] Built-in TUI components (like spinners and progress bars)
-    -   [ ] Automatic command history and completion
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,32 @@
+## Feature Roadmap
+
+This document includes the roadmap for the Chilli project.
+It outlines features to be implemented and their current status.
+
+> [!IMPORTANT]
+> This roadmap is a work in progress and is subject to change.
+
+-   **Command Structure**
+    -   [x] Nested commands and subcommands
+    -   [x] Command aliases and single-character shortcuts
+    -   [x] Persistent flags (flags on parent commands are available to children)
+
+-   **Argument & Flag Parsing**
+    -   [x] Long flags (`--verbose`), short flags (`-v`), and grouped boolean flags (`-vf`)
+    -   [x] Positional Arguments (supports required, optional, and variadic)
+    -   [x] Type-safe access for flags and arguments (e.g., `ctx.getFlag("count", i64)`)
+    -   [x] Reading flag values from environment variables
+
+-   **Help & Usage Output**
+    -   [x] Automatic and context-aware `--help` flag
+    -   [x] Automatic `--version` flag
+    -   [x] Clean, aligned help output for commands, flags, and arguments
+    -   [x] Grouping subcommands into custom sections
+
+-   **Developer Experience**
+    -   [x] Simple, declarative API for building commands
+    -   [x] Named access for all flags and arguments
+    -   [x] Shared context data for passing application state
+    -   [ ] Deprecation notices for commands or flags
+    -   [ ] Built-in TUI components (like spinners and progress bars)
+    -   [ ] Automatic command history and completion

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .chilli,
-    .version = "0.2.1",
+    .version = "0.2.2",
     .fingerprint = 0x6c259741ae4f5f73, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.1",
     .paths = .{


### PR DESCRIPTION
* Moved the Chilli project to this organization (`CogitatorTech`).
* Added issue templates for the project.
* Moved the roadmap information from the main `README.md` to `ROADMAP.md`. 